### PR TITLE
Update app startup logging and add initializer

### DIFF
--- a/src/classes/application.js
+++ b/src/classes/application.js
@@ -4,6 +4,7 @@ const Log = require('@ash-framework/log')
 const loadMiddleware = require('@ash-framework/middleware')
 const express = require('express')
 const path = require('path')
+const fs = require('fs')
 
 const _app = new WeakMap()
 
@@ -12,22 +13,35 @@ module.exports = class Application extends Base {
     const config = require(path.join(process.cwd(), 'config/environment.js'))(process.env.NODE_ENV)
     const MiddlewareRouter = require(path.join(process.cwd(), 'app/middleware.js'))
     const Router = require(path.join(process.cwd(), 'app/router.js'))
+    const log = new Log()
 
+    log.trace('Ash server creating express app instance')
     const app = express()
     _app.set(this, app)
 
-    const log = new Log()
-
-    log.info('Ash server loading middleware')
+    log.trace('Ash server loading middleware')
     const middlewareDir = path.join(process.cwd(), 'app/middleware')
     loadMiddleware(MiddlewareRouter.definition, app, middlewareDir)
 
-    log.info('Ash server loading routes')
+    log.trace('Ash server loading routes')
     const options = {routesDir: path.join(process.cwd(), 'app/routes')}
     app.use(createRoutes(Router.definition, options))
 
+    const initializerDir = path.join(process.cwd(), 'app/initializers')
+    if (fs.existsSync(initializerDir)) {
+      const initializers = fs.readdirSync(initializerDir)
+      if (initializers.length > 0) {
+        log.trace('Ash server loading initializers')
+        initializers.forEach(initializerName => {
+          const Initializer = require(initializerDir + '/' + initializerName)
+          const initializer = new Initializer()
+          initializer.init(app)
+        })
+      }
+    }
+
     app.listen(config.port, function () {
-      log.info(`Ash server started on port ${config.port}`)
+      log.trace(`Ash server started on port ${config.port}`)
     })
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,14 @@
 'use strict'
 
-const {Route, Router, Middleware, MiddlewareRouter, Mixin} = require('@ash-framework/classes')
+const {
+  Route,
+  Router,
+  Middleware,
+  MiddlewareRouter,
+  Mixin,
+  Initializer
+} = require('@ash-framework/classes')
+
 const Log = require('@ash-framework/log')
 
 const Application = require('./classes/application')
@@ -12,7 +20,8 @@ const Ash = {
   MiddlewareRouter,
   log: new Log(),
   Application,
-  Mixin
+  Mixin,
+  Initializer
 }
 
 module.exports = Ash


### PR DESCRIPTION
Adds support for loading initializers to app startup. If no initializers are present, this step is just skipped. @pnw 

See https://github.com/ash-framework/classes/pull/1 for more