### PR TITLE
Add app wide middleware defaults, respect config

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "@ash-framework/http-error": "^1.0.3",
     "@ash-framework/log": "^1.0.0",
     "@ash-framework/middleware": "^1.0.0",
-    "@ash-framework/router": "^0.0.3"
+    "@ash-framework/router": "^0.0.3",
+    "body-parser": "^1.15.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/classes/application.js
+++ b/src/classes/application.js
@@ -9,6 +9,7 @@ const loadMiddleware = require('@ash-framework/middleware')
 const express = require('express')
 const path = require('path')
 const fs = require('fs')
+const bodyparser = require('body-parser')
 
 const _app = new WeakMap()
 
@@ -159,6 +160,21 @@ module.exports = class Application extends Base {
     log.trace('Ash server creating express app instance')
     const app = express()
     _app.set(this, app)
+
+    log.trace('Ash server adding body parsing middleware')
+    const bodyParserOptions = config.bodyParser || {}
+    if (bodyParserOptions.json !== false) {
+      app.use(bodyparser.json(Object.assign({extended: false}, bodyParserOptions.json)))
+    }
+    if (bodyParserOptions.text !== false) {
+      app.use(bodyparser.text(Object.assign({extended: false}, bodyParserOptions.text)))
+    }
+    if (bodyParserOptions.raw !== false) {
+      app.use(bodyparser.raw(Object.assign({extended: false}, bodyParserOptions.raw)))
+    }
+    if (bodyParserOptions.urlencoded !== false) {
+      app.use(bodyparser.urlencoded(Object.assign({extended: false}, bodyParserOptions.urlencoded)))
+    }
 
     const initializerDir = path.join(process.cwd(), 'app/initializers')
     if (fs.existsSync(initializerDir)) {

--- a/src/classes/application.js
+++ b/src/classes/application.js
@@ -163,17 +163,17 @@ module.exports = class Application extends Base {
 
     log.trace('Ash server adding body parsing middleware')
     const bodyParserOptions = config.bodyParser || {}
-    if (bodyParserOptions.json !== false) {
-      app.use(bodyparser.json(Object.assign({extended: false}, bodyParserOptions.json)))
+    if (typeof bodyParserOptions.json === 'object') {
+      app.use(bodyparser.json(bodyParserOptions.json))
     }
-    if (bodyParserOptions.text !== false) {
-      app.use(bodyparser.text(Object.assign({extended: false}, bodyParserOptions.text)))
+    if (typeof bodyParserOptions.text === 'object') {
+      app.use(bodyparser.text(bodyParserOptions.text))
     }
-    if (bodyParserOptions.raw !== false) {
-      app.use(bodyparser.raw(Object.assign({extended: false}, bodyParserOptions.raw)))
+    if (typeof bodyParserOptions.raw === 'object') {
+      app.use(bodyparser.raw(bodyParserOptions.raw))
     }
-    if (bodyParserOptions.urlencoded !== false) {
-      app.use(bodyparser.urlencoded(Object.assign({extended: false}, bodyParserOptions.urlencoded)))
+    if (typeof bodyParserOptions.urlencoded === 'object') {
+      app.use(bodyparser.urlencoded(bodyParserOptions.urlencoded))
     }
 
     const initializerDir = path.join(process.cwd(), 'app/initializers')


### PR DESCRIPTION
Config looks like:

```js
module.exports = function (environment) {
  const ENV = {
    host: 'http://localhost',
    port: 3010
  }

  ENV.cors = {
    origin: ENV.host,
    preflight: true
  }

  ENV.bodyparser = {
    json: {type: 'application/json', extended: false},
    text: {type: 'text/plain', extended: false},
    urlencoded: {type: 'application/x-www-form-urlencoded', extended: false},
    raw: {type: 'application/octet-stream', extended: false}
  }

  return ENV
}

```

1. excluding any bodyParser config results in app wide defaults
2. options are standard body parser options
3. disabling any of the 4 types is possible via setting to false